### PR TITLE
Enhancement of the sidebar widgets text

### DIFF
--- a/assets/sass/base/_base.scss
+++ b/assets/sass/base/_base.scss
@@ -1421,6 +1421,8 @@ button.menu-toggle {
 		li {
 			list-style: none;
 			margin-bottom: ms(-2);
+			padding-left: ms(3);
+			text-indent: -.809em;
 
 			&:before {
 				font-family: "FontAwesome";


### PR DESCRIPTION
These css rules will align the sidebar text that breaks onto a new line to with the first letter, so it doesn't show/wrap underneath the icons. The exact negative value for text-indent should be half of the golden ratio, but I was not able to figure out the Sass formatting for this in combination with ms ( 1.61803 / 2 = 0.809015)